### PR TITLE
adding escaping to string values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+
+test:
+	@./node_modules/.bin/mocha \
+		--reporter spec
+
+PHONY:
+	test

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
   Handlebars helper for `JSON.stringify`.
 
 ## Installation
-  
+
     $ npm install hbs-json
 
 ## Example
@@ -21,15 +21,15 @@ app.get('/', function (req, res, next) {
 
 ```html
  <script>
-    window.user = {{ json user }}
+    window.user = {{{ json user }}}
   </script>
 ```
 
 ## API
 
-### json
-  
-  A handlebars helper for `JSON.stringify`.
+### json obj [escaped]
+
+  A handlebars helper for `JSON.stringify`. By default, will escape html characters so that you may use handlebars to render values to the template.
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var escape = require('escape-html');
+var traverse = require('traverse');
 
 /**
  * Expose `jsonHelper`.
@@ -10,10 +12,27 @@ module.exports = jsonHelper;
  * Stringify json.
  *
  * @param {Object} json
+ * @param {Boolean} escape
  * @return {String}
  */
 
-function jsonHelper (json) {
+function jsonHelper (json, escape) {
   if (!json) return 'null';
+  if (escape === undefined) escape = true;
+  if (escape) json = escapeHtml(json);
   return JSON.stringify(json);
+}
+
+
+/**
+ * Recursively escape any HTML found in nested objects
+ *
+ * @param {Object} obj
+ * @return {Object}
+ */
+
+function escapeHtml (obj) {
+  return traverse(obj).forEach(function (val) {
+    if (typeof val === 'string') this.update(escape(val));
+  });
 }

--- a/package.json
+++ b/package.json
@@ -5,5 +5,12 @@
   "keywords": [
     "handlebars",
     "json"
-  ]
+  ],
+  "dependencies": {
+    "escape-html": "~1.0.1",
+    "traverse": "~0.6.6"
+  },
+  "devDependencies": {
+    "mocha": "~1.16.2"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+var json = require('./');
+
+
+describe('hbs-json', function () {
+  it('should return escaped json by default', function () {
+    var output = json({ html: { text: '<a>alert(0);</a>', v: 5}});
+    assert(output === '{"html":{"text":"&lt;a&gt;alert(0);&lt;/a&gt;","v":5}}');
+  });
+
+  it('should return non-escaped json', function () {
+    var output = json({ html: { text: '<a>alert(0);</a>', v: 5}}, false);
+    assert(output === '{"html":{"text":"<a>alert(0);</a>","v":5}}');
+  });
+});


### PR DESCRIPTION
This commit adds HTML escaping to values within json objects since
we use them directly for rendering from the template into javascript
objects. If that isn't the main use, it might be better splitting
that functionality into a second tag.
